### PR TITLE
Add MobilityDB 1.3 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,23 @@ jobs:
   make-docker-images:
     strategy:
       matrix:
-        postgres: [13, 14, 15, 16, 17]
-        postgis: [3.5]
-        mobilitydb: [1.2, master]
+        include:
+          # MobilityDB 1.2 (PG 13-17, PostGIS 3.5)
+          - { postgres: 13, postgis: 3.5, mobilitydb: 1.2 }
+          - { postgres: 14, postgis: 3.5, mobilitydb: 1.2 }
+          - { postgres: 15, postgis: 3.5, mobilitydb: 1.2 }
+          - { postgres: 16, postgis: 3.5, mobilitydb: 1.2 }
+          - { postgres: 17, postgis: 3.5, mobilitydb: 1.2 }
+          # MobilityDB 1.3 (PG 14-17 on PostGIS 3.5; PG 18 on PostGIS 3.6)
+          - { postgres: 14, postgis: 3.5, mobilitydb: 1.3 }
+          - { postgres: 15, postgis: 3.5, mobilitydb: 1.3 }
+          - { postgres: 16, postgis: 3.5, mobilitydb: 1.3 }
+          - { postgres: 17, postgis: 3.5, mobilitydb: 1.3 }
+          - { postgres: 18, postgis: 3.6, mobilitydb: 1.3 }
+          # MobilityDB master (PG 16-17 on PostGIS 3.5; PG 18 on PostGIS 3.6)
+          - { postgres: 16, postgis: 3.5, mobilitydb: master }
+          - { postgres: 17, postgis: 3.5, mobilitydb: master }
+          - { postgres: 18, postgis: 3.6, mobilitydb: master }
 
     name: Build docker image for ${{ matrix.postgres }}-${{ matrix.postgis }}-${{ matrix.mobilitydb }}
     runs-on: ubuntu-latest

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -14,8 +14,10 @@ jobs:
   make-docker-images:
     strategy:
       matrix:
-        postgres: [13, 14, 15, 16, 17]
-        postgis: [3.5]
+        include:
+          - { postgres: 16, postgis: 3.5 }
+          - { postgres: 17, postgis: 3.5 }
+          - { postgres: 18, postgis: 3.6 }
 
     name: Build docker image for ${{ matrix.postgres }}-${{ matrix.postgis }}-master
     runs-on: ubuntu-latest

--- a/13-3.5-1.2/Dockerfile
+++ b/13-3.5-1.2/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.2
+ARG MOBILITYDB_TAG=v1.2.1
 
 # Install build dependencies
 RUN apt-get update \

--- a/14-3.5-1.2/Dockerfile
+++ b/14-3.5-1.2/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.2
+ARG MOBILITYDB_TAG=v1.2.1
 
 # Install build dependencies
 RUN apt-get update \

--- a/14-3.5-1.3/Dockerfile
+++ b/14-3.5-1.3/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-ARG POSTGRES_VERSION=15
+ARG POSTGRES_VERSION=14
 ARG POSTGIS_VERSION=3.5
 
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=master
+ARG MOBILITYDB_TAG=stable-1.3
 
 # Install build dependencies
 RUN apt-get update \
@@ -36,7 +36,7 @@ WORKDIR /usr/local/src/MobilityDB
 RUN mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-             -DNPOINT=on -DCBUFFER=on -DPOSE=on .. \
+             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on .. \
     && make -j$(nproc) \
     && make install
 

--- a/14-3.5-1.3/Dockerfile
+++ b/14-3.5-1.3/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.3
+ARG MOBILITYDB_TAG=v1.3.0
 
 # Install build dependencies
 RUN apt-get update \

--- a/15-3.5-1.2/Dockerfile
+++ b/15-3.5-1.2/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.2
+ARG MOBILITYDB_TAG=v1.2.1
 
 # Install build dependencies
 RUN apt-get update \

--- a/15-3.5-1.3/Dockerfile
+++ b/15-3.5-1.3/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.3
+ARG MOBILITYDB_TAG=v1.3.0
 
 # Install build dependencies
 RUN apt-get update \

--- a/15-3.5-1.3/Dockerfile
+++ b/15-3.5-1.3/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-ARG POSTGRES_VERSION=17
+ARG POSTGRES_VERSION=15
 ARG POSTGIS_VERSION=3.5
 
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=master
+ARG MOBILITYDB_TAG=stable-1.3
 
 # Install build dependencies
 RUN apt-get update \

--- a/16-3.5-1.2/Dockerfile
+++ b/16-3.5-1.2/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.2
+ARG MOBILITYDB_TAG=v1.2.1
 
 # Install build dependencies
 RUN apt-get update \

--- a/16-3.5-1.3/Dockerfile
+++ b/16-3.5-1.3/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.3
+ARG MOBILITYDB_TAG=v1.3.0
 
 # Install build dependencies
 RUN apt-get update \

--- a/16-3.5-1.3/Dockerfile
+++ b/16-3.5-1.3/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-ARG POSTGRES_VERSION=13
+ARG POSTGRES_VERSION=16
 ARG POSTGIS_VERSION=3.5
 
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=master
+ARG MOBILITYDB_TAG=stable-1.3
 
 # Install build dependencies
 RUN apt-get update \
@@ -36,7 +36,7 @@ WORKDIR /usr/local/src/MobilityDB
 RUN mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-             -DNPOINT=on -DCBUFFER=on -DPOSE=on .. \
+             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on .. \
     && make -j$(nproc) \
     && make install
 

--- a/16-3.5-master/Dockerfile
+++ b/16-3.5-master/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /usr/local/src/MobilityDB
 RUN mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-             -DNPOINT=on -DCBUFFER=on -DPOSE=on .. \
+             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on .. \
     && make -j$(nproc) \
     && make install
 

--- a/17-3.5-1.2/Dockerfile
+++ b/17-3.5-1.2/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.2
+ARG MOBILITYDB_TAG=v1.2.1
 
 # Install build dependencies
 RUN apt-get update \

--- a/17-3.5-1.3/Dockerfile
+++ b/17-3.5-1.3/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-ARG POSTGRES_VERSION=14
+ARG POSTGRES_VERSION=17
 ARG POSTGIS_VERSION=3.5
 
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=master
+ARG MOBILITYDB_TAG=stable-1.3
 
 # Install build dependencies
 RUN apt-get update \
@@ -36,7 +36,7 @@ WORKDIR /usr/local/src/MobilityDB
 RUN mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-             -DNPOINT=on -DCBUFFER=on -DPOSE=on .. \
+             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on .. \
     && make -j$(nproc) \
     && make install
 

--- a/17-3.5-1.3/Dockerfile
+++ b/17-3.5-1.3/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.5
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.3
+ARG MOBILITYDB_TAG=v1.3.0
 
 # Install build dependencies
 RUN apt-get update \

--- a/18-3.6-1.3/Dockerfile
+++ b/18-3.6-1.3/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-ARG POSTGRES_VERSION=17
-ARG POSTGIS_VERSION=3.5
+ARG POSTGRES_VERSION=18
+ARG POSTGIS_VERSION=3.6
 
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=master
+ARG MOBILITYDB_TAG=stable-1.3
 
 # Install build dependencies
 RUN apt-get update \

--- a/18-3.6-1.3/Dockerfile
+++ b/18-3.6-1.3/Dockerfile
@@ -5,7 +5,7 @@ ARG POSTGIS_VERSION=3.6
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG=stable-1.3
+ARG MOBILITYDB_TAG=v1.3.0
 
 # Install build dependencies
 RUN apt-get update \

--- a/18-3.6-master/Dockerfile
+++ b/18-3.6-master/Dockerfile
@@ -1,11 +1,11 @@
 # Build stage
-ARG POSTGRES_VERSION
-ARG POSTGIS_VERSION
+ARG POSTGRES_VERSION=18
+ARG POSTGIS_VERSION=3.6
 
 FROM postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION} AS builder
 
 # Set build arguments
-ARG MOBILITYDB_TAG
+ARG MOBILITYDB_TAG=master
 
 # Install build dependencies
 RUN apt-get update \
@@ -36,7 +36,7 @@ WORKDIR /usr/local/src/MobilityDB
 RUN mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-             -DNPOINT=on -DCBUFFER=on -DPOSE=on .. \
+             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on .. \
     && make -j$(nproc) \
     && make install
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # When processing the rules for tagging and pushing container images with the
 # "latest" tag, the following variable will be the version that is considered
 # to be the latest.
-LATEST_VERSION=17-3.5-1.2
+LATEST_VERSION=18-3.6-1.3
 
 # The following logic evaluates the VERSION variable that may have been previously specified.
 # The VERSIONS variable is set to contain the version(s) to be processed.

--- a/README.md
+++ b/README.md
@@ -56,20 +56,25 @@ docker build -t mobilitydb/mobilitydb:18-3.6-1.3 'https://github.com/MobilityDB/
 Quick Start
 -----------------
 
-* Clone or download this repository
-* Go inside the directory for the desired tag, e.g. `cd 18-3.6-1.3`
-* Run `docker-compose up -d`
+Run a container with the latest release image:
 
-Connect directly with `psql` if you have the PostgreSQL client tool installed:
+```bash
+docker run -d --name mobilitydb \
+    -e POSTGRES_USER=docker \
+    -e POSTGRES_PASSWORD=docker \
+    -e POSTGRES_DB=mobilitydb \
+    -p 25432:5432 \
+    mobilitydb/mobilitydb:latest
+```
+
+Connect with `psql` from the host:
 ```bash
 psql -h localhost -p 25432 -d mobilitydb -U docker
 ```
 
-Or connect from inside the container:
+Or from inside the container:
 ```bash
-docker ps                              # find the container name
-docker exec -it <container_name> bash
-psql -d mobilitydb -U docker
+docker exec -it mobilitydb psql -U docker -d mobilitydb
 ```
 
 Environment

--- a/README.md
+++ b/README.md
@@ -5,71 +5,82 @@ MobilityDB Docker
 
 [MobilityDB](https://github.com/MobilityDB/MobilityDB) is an open source software program that adds support for temporal and spatio-temporal objects to the [PostgreSQL](https://www.postgresql.org/) object-relational database and its spatial extension [PostGIS](http://postgis.net/).
 
-This is a repository to hold various Docker images for MobilityDB releases. The images are based on the official [Postgres](https://github.com/docker-library/postgres) and [Postgis](https://github.com/postgis/docker-postgis) docker images so the documentation for the images also applies here, including the environment variables one can set, extensibility, etc.
-
+This repository builds and publishes Docker images that ship MobilityDB on top of the official [PostgreSQL](https://github.com/docker-library/postgres) + [PostGIS](https://github.com/postgis/docker-postgis) images. All environment variables, mount points, and entrypoint behavior of the upstream `postgis/postgis` images apply here as well.
 
 Requirements
 -----------------
 * [Docker Engine](https://docs.docker.com/install/) version **17.05** or newer
 * [Docker Compose](https://docs.docker.com/compose/install/) version **1.20.0** or newer
 
-Supported tags and respective Dockerfile links
+Tags
 -----------------
-* Master branch of MobilityDB: `mobilitydb/mobilitydb:11-2.5-master`, `mobilitydb/mobilitydb:13-2.5-master` 
-* Develop branch of MobilityDB: `mobilitydb/mobilitydb:12-2.5-develop`
-* MobilityDB v1.0beta: `mobilitydb/mobilitydb:11-2.5-1.0beta`
-* MobilityDB v1.0beta2: `mobilitydb/mobilitydb:12-2.5-1.0beta2`
-* MobilityDB v1.0beta3: `mobilitydb/mobilitydb:13-2.5-1.0beta3`
-* MobilityDB Workshop: `mobilitydb/mobilitydb:12-2.5-develop-workshop`
-* MobilityDB BerlinMOD: `mobilitydb/mobilitydb:12-2.5-develop-berlinmod`
+
+Image names follow the pattern `mobilitydb/mobilitydb:<PG>-<PostGIS>-<MobilityDB>`. Each combination has a corresponding directory in this repository containing its `Dockerfile`.
+
+**MobilityDB 1.3 (latest stable):**
+* `mobilitydb/mobilitydb:14-3.5-1.3`
+* `mobilitydb/mobilitydb:15-3.5-1.3`
+* `mobilitydb/mobilitydb:16-3.5-1.3`
+* `mobilitydb/mobilitydb:17-3.5-1.3`
+* `mobilitydb/mobilitydb:18-3.6-1.3`
+* `mobilitydb/mobilitydb:latest` — alias for `18-3.6-1.3`
+
+**MobilityDB 1.2:**
+* `mobilitydb/mobilitydb:13-3.5-1.2`
+* `mobilitydb/mobilitydb:14-3.5-1.2`
+* `mobilitydb/mobilitydb:15-3.5-1.2`
+* `mobilitydb/mobilitydb:16-3.5-1.2`
+* `mobilitydb/mobilitydb:17-3.5-1.2`
+
+**MobilityDB development (`master` branch):**
+* `mobilitydb/mobilitydb:16-3.5-master`
+* `mobilitydb/mobilitydb:17-3.5-master`
+* `mobilitydb/mobilitydb:18-3.6-master`
+
+The `master` images are rebuilt automatically on every push to `master` in the [MobilityDB](https://github.com/MobilityDB/MobilityDB) repository. The release-tagged images (`-1.2`, `-1.3`) are rebuilt on a weekly schedule from the corresponding `stable-*` branch.
 
 Installation
 -----------------
-Automated builds of the Docker image are available on [Dockerhub](https://hub.docker.com/r/mobilitydb/mobilitydb).
+Pre-built images are available on [Docker Hub](https://hub.docker.com/r/mobilitydb/mobilitydb):
 
 ```bash
 docker pull mobilitydb/mobilitydb:[TAG]
 ```
 
-Alternatively you can build the image locally.
+To build an image locally from this repository, pass the tag's directory as the build context:
 
 ```bash
-docker build -t mobilitydb/mobilitydb 'https://github.com/MobilityDB/MobilityDB-docker.git#master:[TAG]'
+docker build -t mobilitydb/mobilitydb:18-3.6-1.3 'https://github.com/MobilityDB/MobilityDB-docker.git#master:18-3.6-1.3'
 ```
 
 Quick Start
 -----------------
 
 * Clone or download this repository
-* Go inside the required tag `cd 12-2.5-develop`
-* Run this command `docker-compose up -d`
+* Go inside the directory for the desired tag, e.g. `cd 18-3.6-1.3`
+* Run `docker-compose up -d`
 
-Then, you can connect directly with psql if you have the PostgreSQL client tool on your machine:
-```
+Connect directly with `psql` if you have the PostgreSQL client tool installed:
+```bash
 psql -h localhost -p 25432 -d mobilitydb -U docker
 ```
-Otherwise, connect with psql using the container:
-* Get the created container
-	```
-	docker ps
-	```
-* Enter inside the container
-	```
-	docker exec -it <container_name> bash
-	```
-* Connect with psql
-	```
-	psql -d mobilitydb -U docker
+
+Or connect from inside the container:
+```bash
+docker ps                              # find the container name
+docker exec -it <container_name> bash
+psql -d mobilitydb -U docker
+```
 
 Environment
 -----------------
-* `POSTGRES_DB` the default value is **mobilitydb**
-* `POSTGRES_USER` the default value is **docker**
-* `POSTGRES_PASSWORD` the default value is **docker**
+* `POSTGRES_DB` — default `mobilitydb`
+* `POSTGRES_USER` — default `docker`
+* `POSTGRES_PASSWORD` — default `docker`
 
-Access to PgAdmin
+Access from pgAdmin
 -----------------
-* **Host name/address** `localhost`
+* **Host** `localhost`
 * **Port** `25432`
-* **Username** as `POSTGRES_USER`, by default: `docker`
-* **Password** as `POSTGRES_PASSWORD`, by default `docker`
+* **Username** value of `POSTGRES_USER` (default `docker`)
+* **Password** value of `POSTGRES_PASSWORD` (default `docker`)


### PR DESCRIPTION
Adds Dockerfiles for the 1.3.0 release (PG 14-17 + PostGIS 3.5, PG 18 + PostGIS 3.6) and refreshes the matrix accordingly:

- Drop PG 13/14/15 from `master` (1.4dev no longer supports them).
- Pin `*-1.2` and `*-1.3` images to `v1.2.1` and `v1.3.0` instead of moving branch refs.
- Bump `latest` to `18-3.6-1.3`.
- Delete unused `Dockerfile.in`.
- Replace broken `docker-compose` Quick Start with a `docker run` example.