### PR TITLE
Install the h3 extension in the PG 16 and 17 master images

### DIFF
--- a/16-3.5-master/Dockerfile
+++ b/16-3.5-master/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update \
         libgsl-dev \
         libgeos-dev \
         postgresql-server-dev-${PG_MAJOR} \
+        libh3-dev \
+        libh3-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and extract MobilityDB source
@@ -36,7 +38,7 @@ WORKDIR /usr/local/src/MobilityDB
 RUN mkdir -p build \
     && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release \
-             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on .. \
+             -DNPOINT=on -DCBUFFER=on -DPOSE=on -DRGEO=on -DH3=on .. \
     && make -j$(nproc) \
     && make install
 
@@ -54,6 +56,9 @@ LABEL org.opencontainers.image.source="https://github.com/MobilityDB/MobilityDB"
 # Install runtime dependencies only
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        postgresql-${PG_MAJOR}-h3 \
+        postgresql-${PG_MAJOR}-pointcloud \
+        libh3-1 \
         libproj-dev \
         libjson-c-dev \
         libgsl-dev \

--- a/17-3.5-master/Dockerfile
+++ b/17-3.5-master/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get update \
         libxml2-dev \
         libxslt1-dev \
          postgresql-server-dev-${PG_MAJOR} \
+        libh3-dev \
+        libh3-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and extract MobilityDB source
@@ -69,6 +71,8 @@ LABEL org.opencontainers.image.source="https://github.com/MobilityDB/MobilityDB"
 # Install runtime dependencies only
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        postgresql-${PG_MAJOR}-h3 \
+        libh3-1 \
         libproj-dev \
         libjson-c-dev \
         libgsl-dev \


### PR DESCRIPTION
The 18-3.6-master image already installs the h3-pg extension alongside MobilityDB. This PR propagates the same treatment to the other two -master variants so that all images tracking MobilityDB master ship both the h3 and mobilitydb extensions:

- 17-3.5-master: adds libh3-dev/libh3-1 to the builder (its -DALL=on build enables H3) and postgresql-17-h3 + libh3-1 to the runtime.
- 16-3.5-master: same package additions, plus -DH3=on on the cmake line (it enumerates families explicitly) and postgresql-16-pointcloud, which the shared init script already expects (CREATE EXTENSION pointcloud) and which the 18 image installs.

The release-pinned variants (*-1.2, *-1.3) are deliberately untouched: the MobilityDB releases they build do not use h3.

Once MobilityDB master requires the h3 extension for H3-enabled builds, these packages become mandatory for the -master images; installing them is already safe today.